### PR TITLE
:bug: Fixing VMs sometimes coming up blank

### DIFF
--- a/src/Nullinside.Api.Model/Ddl/DockerDeployments.cs
+++ b/src/Nullinside.Api.Model/Ddl/DockerDeployments.cs
@@ -17,6 +17,11 @@ public class DockerDeployments : ITableModel {
   public bool IsDockerComposeProject { get; set; }
 
   /// <summary>
+  ///   The directory on the server where the project is.
+  /// </summary>
+  public string? ServerDir { get; set; }
+
+  /// <summary>
   ///   Gets or sets the docker compose project name if <seealso cref="IsDockerComposeProject" /> is true, else the
   ///   container name.
   /// </summary>
@@ -55,6 +60,8 @@ public class DockerDeployments : ITableModel {
         .HasMaxLength(50)
         .IsRequired();
       entity.Property(e => e.Notes)
+        .HasMaxLength(255);
+      entity.Property(e => e.ServerDir)
         .HasMaxLength(255);
     });
   }

--- a/src/Nullinside.Api.Model/Migrations/20240310041601_DockerDeploymentsDirectory.Designer.cs
+++ b/src/Nullinside.Api.Model/Migrations/20240310041601_DockerDeploymentsDirectory.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nullinside.Api.Model;
 
@@ -10,9 +11,11 @@ using Nullinside.Api.Model;
 namespace Nullinside.Api.Model.Migrations
 {
     [DbContext(typeof(NullinsideContext))]
-    partial class NullinsideContextModelSnapshot : ModelSnapshot
+    [Migration("20240310041601_DockerDeploymentsDirectory")]
+    partial class DockerDeploymentsDirectory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Nullinside.Api.Model/Migrations/20240310041601_DockerDeploymentsDirectory.cs
+++ b/src/Nullinside.Api.Model/Migrations/20240310041601_DockerDeploymentsDirectory.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nullinside.Api.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class DockerDeploymentsDirectory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ServerDir",
+                table: "DockerDeployments",
+                type: "varchar(255)",
+                maxLength: 255,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ServerDir",
+                table: "DockerDeployments");
+        }
+    }
+}

--- a/src/Nullinside.Api/Controllers/DockerController.cs
+++ b/src/Nullinside.Api/Controllers/DockerController.cs
@@ -69,12 +69,8 @@ public class DockerController : ControllerBase {
         knownDeployment.IsDockerComposeProject
           ? projects.Result.FirstOrDefault(c => c.Name?.Equals(knownDeployment.Name, StringComparison.InvariantCultureIgnoreCase) ?? false)
           : containers.Result.FirstOrDefault(c => c.Name?.Equals(knownDeployment.Name, StringComparison.InvariantCultureIgnoreCase) ?? false);
-      if (null == existingContainer) {
-        continue;
-      }
-
       response.Add(new DockerResource(knownDeployment) {
-        IsOnline = existingContainer.IsOnline
+        IsOnline = existingContainer is { IsOnline: true }
       });
     }
 
@@ -100,7 +96,7 @@ public class DockerController : ControllerBase {
 
     bool result;
     if (recognizedProjects.IsDockerComposeProject) {
-      result = await _docker.TurnOnOffDockerCompose(recognizedProjects.Name, request.TurnOn, token);
+      result = await _docker.TurnOnOffDockerCompose(recognizedProjects.Name, request.TurnOn, token, recognizedProjects.ServerDir);
     }
     else {
       result = await _docker.TurnOnOffDockerContainer(recognizedProjects.Name, request.TurnOn, token);

--- a/src/Nullinside.Api/Shared/Support/IDockerProxy.cs
+++ b/src/Nullinside.Api/Shared/Support/IDockerProxy.cs
@@ -33,6 +33,7 @@ public interface IDockerProxy {
   /// <param name="name">The project name.</param>
   /// <param name="turnOn">True to start the resource up, false to turn it off.</param>
   /// <param name="cancellationToken">The cancellation token.</param>
+  /// <param name="backupDir">If the compose project doesn't already exist, the directory to find it in.</param>
   /// <returns>True if successful, false otherwise.</returns>
-  Task<bool> TurnOnOffDockerCompose(string name, bool turnOn, CancellationToken cancellationToken);
+  Task<bool> TurnOnOffDockerCompose(string name, bool turnOn, CancellationToken cancellationToken, string? backupDir);
 }


### PR DESCRIPTION
Garbage collection was removing the old VMs from docker thus making it so we couldn't rely on the simple start and stop only. Added the directory with the fully configured services into the database. If the service isn't available to start/stop we will use the directory to start it.

closes #8