### PR TITLE
Adding auth flow for twitch

### DIFF
--- a/src/Nullinside.Api.Common.AspNetCore/Middleware/BasicAuthenticationHandler.cs
+++ b/src/Nullinside.Api.Common.AspNetCore/Middleware/BasicAuthenticationHandler.cs
@@ -72,7 +72,7 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
     try {
       //auth logic
       List<Claim> claims = [
-        new Claim(ClaimTypes.Email, dbUser.Gmail ?? string.Empty),
+        new Claim(ClaimTypes.Email, dbUser.Email ?? string.Empty),
         new Claim(ClaimTypes.UserData, dbUser.Id.ToString())
       ];
 

--- a/src/Nullinside.Api.Common.AspNetCore/Nullinside.Api.Common.AspNetCore.csproj
+++ b/src/Nullinside.Api.Common.AspNetCore/Nullinside.Api.Common.AspNetCore.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Nullinside.Api.Common/Exceptions/RetryException.cs
+++ b/src/Nullinside.Api.Common/Exceptions/RetryException.cs
@@ -1,0 +1,40 @@
+﻿namespace Nullinside.Api.Common.Exceptions;
+
+/// <summary>
+///   An exception thrown if an action continues to fail after retrying.
+/// </summary>
+public class RetryException : Exception {
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="RetryException" /> class.
+  /// </summary>
+  public RetryException() {
+  }
+
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="RetryException" /> class.
+  /// </summary>
+  /// <param name="message">The exception message.</param>
+  public RetryException(string message) : base(message) {
+  }
+
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="RetryException" /> class.
+  /// </summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="inner">The inner exception.</param>
+  public RetryException(string message, Exception inner) : base(message, inner) {
+  }
+
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="RetryException" /> class.
+  /// </summary>
+  /// <param name="thrownExceptions">The exceptions thrown when retrying the method, in the order they are thrown.</param>
+  public RetryException(IEnumerable<Exception> thrownExceptions) {
+    ThrownExceptions = thrownExceptions;
+  }
+
+  /// <summary>
+  ///   The exceptions thrown when retrying the method, in the order they are thrown.
+  /// </summary>
+  public IEnumerable<Exception>? ThrownExceptions { get; }
+}

--- a/src/Nullinside.Api.Common/Retry.cs
+++ b/src/Nullinside.Api.Common/Retry.cs
@@ -1,0 +1,49 @@
+﻿using Nullinside.Api.Common.Exceptions;
+
+namespace Nullinside.Api.Common;
+
+/// <summary>
+///   A helper class for re-running methods more than once.
+/// </summary>
+public static class Retry {
+  /// <summary>
+  ///   Re-runs the provided action multiple times, stopping when it executes successfully or runs out of retries.
+  /// </summary>
+  /// <param name="action">The action to execute.</param>
+  /// <param name="numberOfRetries">The number of times to retry, on failure, inclusive.</param>
+  /// <param name="token">The cancellation.</param>
+  /// <param name="waitTime">The, optional, time to wait between retries. If null, no wait.</param>
+  /// <param name="runOnFailure">
+  ///   The, optional, action to run after a failure has occurred. Runs AFTER the specified <paramref name="waitTime" />.
+  /// </param>
+  /// <remarks>
+  ///   Success or failure of the execution of <paramref name="action" /> is entirely judged based on the presence or
+  ///   absence of a throw exception.
+  /// </remarks>
+  /// <typeparam name="T">The return type of the <paramref name="action" />.</typeparam>
+  /// <returns>Whatever <paramref name="action" /> returns, if successful. Throws <see cref="RetryException" /> on failures.</returns>
+  /// <exception cref="RetryException">
+  ///   <paramref name="action" /> was executed <paramref name="numberOfRetries" /> times and it never
+  ///   succeeded.
+  /// </exception>
+  public static async Task<T> Execute<T>(Func<Task<T>> action, int numberOfRetries, CancellationToken token = new(), TimeSpan? waitTime = null, Action<Exception>? runOnFailure = null) {
+    int tries = 0;
+    while (tries <= numberOfRetries && !token.IsCancellationRequested) {
+      try {
+        return await action();
+      }
+      catch (Exception ex) {
+        ++tries;
+
+        // Why did I do as delay THEN method? Honestly...I don't have a good reason. You can change it if you want, just
+        // update the documentation if you do.
+        await Task.Delay(waitTime.HasValue ? (int)waitTime.Value.TotalMilliseconds : 1000, token);
+        if (null != runOnFailure) {
+          runOnFailure(ex);
+        }
+      }
+    }
+
+    throw new RetryException($"Error after {tries} tries");
+  }
+}

--- a/src/Nullinside.Api.Model/Ddl/User.cs
+++ b/src/Nullinside.Api.Model/Ddl/User.cs
@@ -12,14 +12,29 @@ public class User : ITableModel {
   public int Id { get; set; }
 
   /// <summary>
-  ///   The user's gmail account, if signed up with.
+  ///   The user's email account.
   /// </summary>
-  public string? Gmail { get; set; }
+  public string? Email { get; set; }
 
   /// <summary>
   ///   The user's auth token for interacting with the site's API.
   /// </summary>
   public string? Token { get; set; }
+
+  /// <summary>
+  ///   The oauth token for interacting with the twitch API.
+  /// </summary>
+  public string? TwitchToken { get; set; }
+
+  /// <summary>
+  ///   The refresh token for interacting with the twitch API.
+  /// </summary>
+  public string? TwitchRefreshToken { get; set; }
+
+  /// <summary>
+  ///   When the <see cref="TwitchToken" /> expires.
+  /// </summary>
+  public DateTime? TwitchTokenExpiration { get; set; }
 
   /// <summary>
   ///   The last timestamp of when the user logged into the site.
@@ -43,10 +58,10 @@ public class User : ITableModel {
   public void OnModelCreating(ModelBuilder modelBuilder) {
     modelBuilder.Entity<User>(entity => {
       entity.HasKey(e => e.Id);
-      entity.HasIndex(e => e.Gmail)
+      entity.HasIndex(e => e.Email)
         .IsUnique();
       entity.HasMany(e => e.Roles);
-      entity.Property(e => e.Gmail)
+      entity.Property(e => e.Email)
         .HasMaxLength(255);
       entity.Property(e => e.Token)
         .HasMaxLength(255);

--- a/src/Nullinside.Api.Model/Migrations/20240323012107_Twitch.Designer.cs
+++ b/src/Nullinside.Api.Model/Migrations/20240323012107_Twitch.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nullinside.Api.Model;
 
@@ -10,9 +11,11 @@ using Nullinside.Api.Model;
 namespace Nullinside.Api.Model.Migrations
 {
     [DbContext(typeof(NullinsideContext))]
-    partial class NullinsideContextModelSnapshot : ModelSnapshot
+    [Migration("20240323012107_Twitch")]
+    partial class Twitch
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Nullinside.Api.Model/Migrations/20240323012107_Twitch.cs
+++ b/src/Nullinside.Api.Model/Migrations/20240323012107_Twitch.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nullinside.Api.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class Twitch : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder) {
+            migrationBuilder.Sql("""
+                ALTER TABLE Users
+                RENAME COLUMN Gmail TO Email;
+            """);
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Users_Gmail",
+                table: "Users",
+                newName: "IX_Users_Email");
+
+            migrationBuilder.AddColumn<string>(
+                name: "TwitchRefreshToken",
+                table: "Users",
+                type: "longtext",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TwitchToken",
+                table: "Users",
+                type: "longtext",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "TwitchTokenExpiration",
+                table: "Users",
+                type: "datetime(6)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TwitchRefreshToken",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "TwitchToken",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "TwitchTokenExpiration",
+                table: "Users");
+            
+            migrationBuilder.Sql("""
+                ALTER TABLE Users
+                RENAME COLUMN Email TO Gmail;
+            """);
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Users_Email",
+                table: "Users",
+                newName: "IX_Users_Gmail");
+        }
+    }
+}

--- a/src/Nullinside.Api.Model/Nullinside.Api.Model.csproj
+++ b/src/Nullinside.Api.Model/Nullinside.Api.Model.csproj
@@ -16,8 +16,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Nullinside.Api.Tests/Nullinside.Api.Tests.csproj
+++ b/src/Nullinside.Api.Tests/Nullinside.Api.Tests.csproj
@@ -17,11 +17,11 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
         <PackageReference Include="NUnit" Version="4.1.0"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+        <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.1">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Nullinside.Api/Nullinside.Api.csproj
+++ b/src/Nullinside.Api/Nullinside.Api.csproj
@@ -22,13 +22,14 @@
 
     <ItemGroup>
         <PackageReference Include="Google.Apis.Oauth2.v2" Version="1.67.0.1869"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="MySql.EntityFrameworkCore" Version="8.0.0"/>
         <PackageReference Include="SSH.NET" Version="2024.0.0"/>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="TwitchLib.Api" Version="3.9.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Nullinside.Api/Properties/example-launchSettings.json
+++ b/src/Nullinside.Api/Properties/example-launchSettings.json
@@ -15,7 +15,10 @@
         "DOCKER_SERVER": "",
         "DOCKER_USERNAME": "",
         "DOCKER_PASSWORD": "",
-        "DOCKER_PASSWORD2": ""
+        "DOCKER_PASSWORD2": "",
+        "TWITCH_BOT_CLIENT_ID": "",
+        "TWITCH_BOT_CLIENT_SECRET": "",
+        "TWITCH_BOT_CLIENT_REDIRECT": ""
       }
     },
     "https": {

--- a/src/Nullinside.Api/Shared/TwitchApiProxy.cs
+++ b/src/Nullinside.Api/Shared/TwitchApiProxy.cs
@@ -1,0 +1,122 @@
+﻿using Nullinside.Api.Common;
+
+using TwitchLib.Api;
+using TwitchLib.Api.Auth;
+using TwitchLib.Api.Helix.Models.Users.GetUsers;
+
+namespace Nullinside.Api.Shared;
+
+/// <summary>
+///   A proxy for making twitch requests.
+/// </summary>
+public class TwitchApiProxy {
+  /// <summary>
+  ///   The, public, twitch client id.
+  /// </summary>
+  public static string ClientId { get; } = Environment.GetEnvironmentVariable("TWITCH_BOT_CLIENT_ID")!;
+
+  /// <summary>
+  ///   The, private, twitch client secret.
+  /// </summary>
+  public static string ClientSecret { get; } = Environment.GetEnvironmentVariable("TWITCH_BOT_CLIENT_SECRET")!;
+
+  /// <summary>
+  ///   The redirect url.
+  /// </summary>
+  public static string ClientRedirect { get; } = Environment.GetEnvironmentVariable("TWITCH_BOT_CLIENT_REDIRECT")!;
+
+  /// <summary>
+  ///   The Twitch access token.
+  /// </summary>
+  public string? AccessToken { get; set; }
+
+  /// <summary>
+  ///   The refresh token.
+  /// </summary>
+  public string? RefreshToken { get; set; }
+
+  /// <summary>
+  ///   The UTC <see cref="DateTime" /> when the <see cref="AccessToken" /> expires.
+  /// </summary>
+  public DateTime? ExpiresUtc { get; set; }
+
+  /// <summary>
+  ///   The number of times to retry queries before giving up.
+  /// </summary>
+  public int Retries { get; set; } = 3;
+
+  /// <summary>
+  ///   Gets a new instance of the <see cref="TwitchAPI" />.
+  /// </summary>
+  /// <returns>A new instance of the <see cref="TwitchAPI" />.</returns>
+  private TwitchAPI GetApi() {
+    var api = new TwitchAPI {
+      Settings = {
+        ClientId = ClientId,
+        AccessToken = AccessToken
+      }
+    };
+    return api;
+  }
+
+  /// <summary>
+  ///   Refreshes the access token.
+  /// </summary>
+  /// <param name="token">The cancellation token.</param>
+  /// <remarks>The object will have it's properties updated with the new settings for the token.</remarks>
+  /// <returns>True if successful, false otherwise.</returns>
+  public async Task<bool> RefreshTokenAsync(CancellationToken token = new()) {
+    try {
+      TwitchAPI api = GetApi();
+      RefreshResponse? response = await api.Auth.RefreshAuthTokenAsync(RefreshToken, ClientSecret, ClientId);
+      if (null == response) {
+        return false;
+      }
+
+      AccessToken = response.AccessToken;
+      RefreshToken = response.RefreshToken;
+      ExpiresUtc = DateTime.UtcNow + TimeSpan.FromSeconds(response.ExpiresIn);
+      return true;
+    }
+    catch (Exception) {
+      return false;
+    }
+  }
+
+  /// <summary>
+  ///   Gets a new access token.
+  /// </summary>
+  /// <param name="code">The code to send to twitch to generate a new access token.</param>
+  /// <param name="token">The cancellation token.</param>
+  /// <remarks>The object will have it's properties updated with the new settings for the token.</remarks>
+  /// <returns>True if successful, false otherwise.</returns>
+  public async Task<bool> GetAccessToken(string code, CancellationToken token = new()) {
+    TwitchAPI api = GetApi();
+    AuthCodeResponse? response = await api.Auth.GetAccessTokenFromCodeAsync(code, ClientSecret, ClientRedirect);
+    if (null == response) {
+      return false;
+    }
+
+    AccessToken = response.AccessToken;
+    RefreshToken = response.RefreshToken;
+    ExpiresUtc = DateTime.UtcNow + TimeSpan.FromSeconds(response.ExpiresIn);
+    return true;
+  }
+
+  /// <summary>
+  ///   Gets the email address of the owner of the <see cref="AccessToken" />.
+  /// </summary>
+  /// <param name="token">The cancellation token.</param>
+  /// <returns>The email address if successful, null otherwise.</returns>
+  public async Task<string?> GetUserEmail(CancellationToken token = new()) {
+    return await Retry.Execute(async () => {
+      TwitchAPI api = GetApi();
+      GetUsersResponse? response = await api.Helix.Users.GetUsersAsync();
+      if (null == response) {
+        return null;
+      }
+
+      return response.Users.FirstOrDefault()?.Email;
+    }, Retries, token);
+  }
+}


### PR DESCRIPTION
Adding auth flow to authenticate people with twitch.

The intention here is not to save a OAuth token with twitch for later use. We are ONLY using the email read permission to validate the user's email address and save it to the database to identify their saved resources. The OAuth token in this code should NOT be used to make other twitch requests. 