### PR TITLE
Adding GitHub helpers for checking version number

### DIFF
--- a/src/Nullinside.Api.Common/Constants.cs
+++ b/src/Nullinside.Api.Common/Constants.cs
@@ -1,0 +1,17 @@
+﻿namespace Nullinside.Api.Common;
+
+/// <summary>
+/// Constant strings used throughout the application.
+/// </summary>
+public static class Constants {
+  /// <summary>
+  /// The API for getting the latest release version number.
+  /// </summary>
+  public const string APP_UPDATE_API = "https://api.github.com/repos/{0}/{1}/releases/latest";
+
+  /// <summary>
+  /// The user agent a browser would use in its headers.
+  /// </summary>
+  public const string FAKE_USER_AGENT =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36";
+}

--- a/src/Nullinside.Api.Common/Desktop/GitHubUpdateManager.cs
+++ b/src/Nullinside.Api.Common/Desktop/GitHubUpdateManager.cs
@@ -1,0 +1,39 @@
+﻿using System.Net;
+
+using Newtonsoft.Json;
+
+namespace Nullinside.Api.Common.Desktop;
+
+/// <summary>
+///   Handles checking for updates to the application via GitHub releases.
+/// </summary>
+public class GitHubUpdateManager {
+  /// <summary>
+  ///   Gets the latest version number of the release.
+  /// </summary>
+  /// <param name="owner">The owner of the repository.</param>
+  /// <param name="repo">The repository name.</param>
+  /// <returns>The response from GitHub.</returns>
+  public static async Task<GithubLatestReleaseJson?> GetLatestVersion(string owner, string repo) {
+    if (string.IsNullOrWhiteSpace(owner)) {
+      throw new ArgumentException("Cannot be null or whitespace", nameof(owner));
+    }
+    
+    if (string.IsNullOrWhiteSpace(repo)) {
+      throw new ArgumentException("Cannot be null or whitespace", nameof(repo));
+    }
+    
+    var handler = new HttpClientHandler();
+    handler.AutomaticDecompression = ~DecompressionMethods.None;
+    using var httpClient = new HttpClient(handler);
+    using var request = new HttpRequestMessage(HttpMethod.Get, string.Format(Constants.APP_UPDATE_API, owner, repo));
+    request.Headers.TryAddWithoutValidation("user-agent", Constants.FAKE_USER_AGENT);
+    HttpResponseMessage response = await httpClient.SendAsync(request);
+    if (!response.IsSuccessStatusCode) {
+      return null;
+    }
+
+    string body = await response.Content.ReadAsStringAsync();
+    return JsonConvert.DeserializeObject<GithubLatestReleaseJson>(body);
+  }
+}

--- a/src/Nullinside.Api.Common/Desktop/GithubLatestReleaseJson.cs
+++ b/src/Nullinside.Api.Common/Desktop/GithubLatestReleaseJson.cs
@@ -1,0 +1,16 @@
+﻿namespace Nullinside.Api.Common.Desktop;
+
+/// <summary>
+///   The response information from GitHub's API.
+/// </summary>
+public class GithubLatestReleaseJson {
+  /// <summary>
+  ///   The url of the resource.
+  /// </summary>
+  public string? html_url { get; set; }
+
+  /// <summary>
+  ///   The name of the release.
+  /// </summary>
+  public string? name { get; set; }
+}


### PR DESCRIPTION
Adding version numbering so that Desktop applications can use GitHub releases as a way of alerting users that there are new versions.