### PR TITLE
Logging when we ban someone successfully

### DIFF
--- a/src/Nullinside.Api.Common/Twitch/TwitchApiProxy.cs
+++ b/src/Nullinside.Api.Common/Twitch/TwitchApiProxy.cs
@@ -240,6 +240,7 @@ public class TwitchApiProxy {
           }
 
           bannedUsers.AddRange(response.Data);
+          Log.Debug($"Banned {user.Username} ({user.Id}) in {channelId}: {reason}");
         }
         catch (HttpResponseException ex) {
           string exceptionReason = await ex.HttpResponse.Content.ReadAsStringAsync(token);


### PR DESCRIPTION
It just makes it easier to see what's going on in grafana. Right now the service is so quiet it's hard to tell if it's doing anything at all.