### PR TITLE
Downgrading packages that aren't working

### DIFF
--- a/src/Nullinside.Api.Common/Nullinside.Api.Common.csproj
+++ b/src/Nullinside.Api.Common/Nullinside.Api.Common.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="log4net" Version="3.0.3" />
+        <PackageReference Include="log4net" Version="2.0.17" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
         <PackageReference Include="SSH.NET" Version="2024.2.0" />

--- a/src/Nullinside.Api/Nullinside.Api.csproj
+++ b/src/Nullinside.Api/Nullinside.Api.csproj
@@ -22,7 +22,8 @@
 
     <ItemGroup>
         <PackageReference Include="Google.Apis.Oauth2.v2" Version="1.68.0.1869"/>
-        <PackageReference Include="log4net.Ext.Json" Version="3.0.1" />
+        <PackageReference Include="log4net" Version="2.0.17" />
+        <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -33,6 +34,7 @@
         <PackageReference Include="SSH.NET" Version="2024.2.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
         <PackageReference Include="System.Text.Json" Version="8.0.5" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Include="TwitchLib.Api" Version="3.9.0"/>
     </ItemGroup>
 


### PR DESCRIPTION
log4net isn't outputting any data. No idea if it's the 3rd party json package or log4net itself. Will have to see if there are migration guides anywhere to see what we're doing wrong.