### PR TITLE
feat: using database lock to protect bot api token

### DIFF
--- a/src/Nullinside.Api.Common/Nullinside.Api.Common.csproj
+++ b/src/Nullinside.Api.Common/Nullinside.Api.Common.csproj
@@ -16,10 +16,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="log4net" Version="2.0.17" />
+        <PackageReference Include="log4net" Version="2.0.17"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="SSH.NET" Version="2024.2.0" />
+        <PackageReference Include="SSH.NET" Version="2024.2.0"/>
         <PackageReference Include="TwitchLib.Api" Version="3.9.0"/>
         <PackageReference Include="TwitchLib.Client" Version="3.3.1"/>
     </ItemGroup>

--- a/src/Nullinside.Api.Common/Twitch/ITwitchApiProxy.cs
+++ b/src/Nullinside.Api.Common/Twitch/ITwitchApiProxy.cs
@@ -14,7 +14,7 @@ public interface ITwitchApiProxy {
   ///   The Twitch access token. These are the credentials used for all requests.
   /// </summary>
   TwitchAccessToken? OAuth { get; set; }
-  
+
   /// <summary>
   ///   The Twitch app configuration. These are used for all requests.
   /// </summary>

--- a/src/Nullinside.Api.Common/Twitch/TwitchApiProxy.cs
+++ b/src/Nullinside.Api.Common/Twitch/TwitchApiProxy.cs
@@ -33,7 +33,7 @@ public class TwitchApiProxy : ITwitchApiProxy {
   ///   Initializes a new instance of the <see cref="TwitchApiProxy" /> class.
   /// </summary>
   public TwitchApiProxy() {
-    TwitchAppConfig = new() {
+    TwitchAppConfig = new TwitchAppConfig {
       ClientId = Environment.GetEnvironmentVariable("TWITCH_BOT_CLIENT_ID"),
       ClientSecret = Environment.GetEnvironmentVariable("TWITCH_BOT_CLIENT_SECRET"),
       ClientRedirect = Environment.GetEnvironmentVariable("TWITCH_BOT_CLIENT_REDIRECT")
@@ -46,21 +46,27 @@ public class TwitchApiProxy : ITwitchApiProxy {
   /// <param name="token">The access token.</param>
   /// <param name="refreshToken">The refresh token.</param>
   /// <param name="tokenExpires">When the token expires (utc).</param>
-  /// <param name="clientId">The client id of the registered twitch app, uses environment variable
-  /// "TWITCH_BOT_CLIENT_ID" when null.</param>
-  /// <param name="clientSecret">The client secret of the registered twitch app, uses environment variable
-  /// "TWITCH_BOT_CLIENT_SECRET" when null.</param>
-  /// <param name="clientRedirect">The url to redirect to from the registered twitch app, uses environment variable
-  /// "TWITCH_BOT_CLIENT_REDIRECT" when null.</param>
-  public TwitchApiProxy(string token, string refreshToken, DateTime tokenExpires, string? clientId = null, 
+  /// <param name="clientId">
+  ///   The client id of the registered twitch app, uses environment variable
+  ///   "TWITCH_BOT_CLIENT_ID" when null.
+  /// </param>
+  /// <param name="clientSecret">
+  ///   The client secret of the registered twitch app, uses environment variable
+  ///   "TWITCH_BOT_CLIENT_SECRET" when null.
+  /// </param>
+  /// <param name="clientRedirect">
+  ///   The url to redirect to from the registered twitch app, uses environment variable
+  ///   "TWITCH_BOT_CLIENT_REDIRECT" when null.
+  /// </param>
+  public TwitchApiProxy(string token, string refreshToken, DateTime tokenExpires, string? clientId = null,
     string? clientSecret = null, string? clientRedirect = null) {
     OAuth = new TwitchAccessToken {
       AccessToken = token,
       RefreshToken = refreshToken,
       ExpiresUtc = tokenExpires
     };
-    
-    TwitchAppConfig = new() {
+
+    TwitchAppConfig = new TwitchAppConfig {
       ClientId = clientId ?? Environment.GetEnvironmentVariable("TWITCH_BOT_CLIENT_ID"),
       ClientSecret = clientSecret ?? Environment.GetEnvironmentVariable("TWITCH_BOT_CLIENT_SECRET"),
       ClientRedirect = clientRedirect ?? Environment.GetEnvironmentVariable("TWITCH_BOT_CLIENT_REDIRECT")
@@ -74,14 +80,14 @@ public class TwitchApiProxy : ITwitchApiProxy {
 
   /// <inheritdoc />
   public virtual TwitchAccessToken? OAuth { get; set; }
-  
+
   /// <inheritdoc />
   public virtual TwitchAppConfig? TwitchAppConfig { get; set; }
 
   /// <inheritdoc />
   public virtual async Task<TwitchAccessToken?> CreateAccessToken(string code, CancellationToken token = new()) {
     ITwitchAPI api = GetApi();
-    AuthCodeResponse? response = await api.Auth.GetAccessTokenFromCodeAsync(code, TwitchAppConfig?.ClientSecret, 
+    AuthCodeResponse? response = await api.Auth.GetAccessTokenFromCodeAsync(code, TwitchAppConfig?.ClientSecret,
       TwitchAppConfig?.ClientRedirect);
     if (null == response) {
       return null;
@@ -101,7 +107,7 @@ public class TwitchApiProxy : ITwitchApiProxy {
       if (string.IsNullOrWhiteSpace(TwitchAppConfig?.ClientSecret) || string.IsNullOrWhiteSpace(TwitchAppConfig?.ClientId)) {
         return null;
       }
-      
+
       ITwitchAPI api = GetApi();
       RefreshResponse? response = await api.Auth.RefreshAuthTokenAsync(OAuth?.RefreshToken, TwitchAppConfig?.ClientSecret, TwitchAppConfig?.ClientId);
       if (null == response) {
@@ -145,7 +151,7 @@ public class TwitchApiProxy : ITwitchApiProxy {
   }
 
   /// <inheritdoc />
-  public virtual  async Task<string?> GetUserEmail(CancellationToken token = new()) {
+  public virtual async Task<string?> GetUserEmail(CancellationToken token = new()) {
     return await Retry.Execute(async () => {
       ITwitchAPI api = GetApi();
       GetUsersResponse? response = await api.Helix.Users.GetUsersAsync();
@@ -158,7 +164,7 @@ public class TwitchApiProxy : ITwitchApiProxy {
   }
 
   /// <inheritdoc />
-  public virtual  async Task<IEnumerable<TwitchModeratedChannel>> GetUserModChannels(string userId) {
+  public virtual async Task<IEnumerable<TwitchModeratedChannel>> GetUserModChannels(string userId) {
     using var client = new HttpClient();
 
     var ret = new List<TwitchModeratedChannel>();
@@ -189,7 +195,7 @@ public class TwitchApiProxy : ITwitchApiProxy {
   }
 
   /// <inheritdoc />
-  public virtual  async Task<IEnumerable<BannedUser>> BanChannelUsers(string channelId, string botId,
+  public virtual async Task<IEnumerable<BannedUser>> BanChannelUsers(string channelId, string botId,
     IEnumerable<(string Id, string Username)> users, string reason, CancellationToken token = new()) {
     return await Retry.Execute(async () => {
       ITwitchAPI api = GetApi();
@@ -223,7 +229,7 @@ public class TwitchApiProxy : ITwitchApiProxy {
   }
 
   /// <inheritdoc />
-  public virtual  async Task<IEnumerable<Chatter>> GetChannelUsers(string channelId, string botId,
+  public virtual async Task<IEnumerable<Chatter>> GetChannelUsers(string channelId, string botId,
     CancellationToken token = new()) {
     return await Retry.Execute(async () => {
       ITwitchAPI api = GetApi();
@@ -247,7 +253,7 @@ public class TwitchApiProxy : ITwitchApiProxy {
   }
 
   /// <inheritdoc />
-  public virtual  async Task<IEnumerable<string>> GetChannelsLive(IEnumerable<string> userIds) {
+  public virtual async Task<IEnumerable<string>> GetChannelsLive(IEnumerable<string> userIds) {
     ITwitchAPI api = GetApi();
 
     // We can only query 100 at a time, so throttle the search.
@@ -271,7 +277,7 @@ public class TwitchApiProxy : ITwitchApiProxy {
   }
 
   /// <inheritdoc />
-  public virtual  async Task<IEnumerable<Moderator>> GetChannelMods(string channelId, CancellationToken token = new()) {
+  public virtual async Task<IEnumerable<Moderator>> GetChannelMods(string channelId, CancellationToken token = new()) {
     return await Retry.Execute(async () => {
       ITwitchAPI api = GetApi();
 
@@ -298,7 +304,7 @@ public class TwitchApiProxy : ITwitchApiProxy {
   }
 
   /// <inheritdoc />
-  public virtual  async Task<bool> AddChannelMod(string channelId, string userId, CancellationToken token = new()) {
+  public virtual async Task<bool> AddChannelMod(string channelId, string userId, CancellationToken token = new()) {
     return await Retry.Execute(async () => {
       ITwitchAPI api = GetApi();
       await api.Helix.Moderation.AddChannelModeratorAsync(channelId, userId);

--- a/src/Nullinside.Api.Common/Twitch/TwitchAppConfig.cs
+++ b/src/Nullinside.Api.Common/Twitch/TwitchAppConfig.cs
@@ -1,21 +1,21 @@
 namespace Nullinside.Api.Common.Twitch;
 
 /// <summary>
-/// The configuration for a twitch app that provides OAuth tokens.
+///   The configuration for a twitch app that provides OAuth tokens.
 /// </summary>
 public class TwitchAppConfig {
   /// <summary>
-  /// The client id.
+  ///   The client id.
   /// </summary>
   public string? ClientId { get; set; }
-  
+
   /// <summary>
-  /// The client secret.
+  ///   The client secret.
   /// </summary>
   public string? ClientSecret { get; set; }
-  
+
   /// <summary>
-  /// A registered URL that the Twitch API is allowed to redirect to on our website.
+  ///   A registered URL that the Twitch API is allowed to redirect to on our website.
   /// </summary>
   public string? ClientRedirect { get; set; }
 }

--- a/src/Nullinside.Api.Model/Ddl/User.cs
+++ b/src/Nullinside.Api.Model/Ddl/User.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 using Microsoft.EntityFrameworkCore;
 
 namespace Nullinside.Api.Model.Ddl;
@@ -60,6 +62,7 @@ public class User : ITableModel {
   /// <summary>
   ///   The last timestamp of when the user logged into the site.
   /// </summary>
+  [Timestamp]
   public DateTime UpdatedOn { get; set; }
 
   /// <summary>
@@ -92,6 +95,8 @@ public class User : ITableModel {
         .HasMaxLength(255);
       entity.Property(e => e.Token)
         .HasMaxLength(255);
+      entity.Property(e => e.UpdatedOn)
+        .IsRowVersion();
       // TODO: Add the other strings in this file with lengths
     });
   }

--- a/src/Nullinside.Api.Model/Migrations/20250228164901_UserTableTimestamp.Designer.cs
+++ b/src/Nullinside.Api.Model/Migrations/20250228164901_UserTableTimestamp.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nullinside.Api.Model;
 
@@ -10,9 +11,11 @@ using Nullinside.Api.Model;
 namespace Nullinside.Api.Model.Migrations
 {
     [DbContext(typeof(NullinsideContext))]
-    partial class NullinsideContextModelSnapshot : ModelSnapshot
+    [Migration("20250228164901_UserTableTimestamp")]
+    partial class UserTableTimestamp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Nullinside.Api.Model/Migrations/20250228164901_UserTableTimestamp.cs
+++ b/src/Nullinside.Api.Model/Migrations/20250228164901_UserTableTimestamp.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using MySql.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace Nullinside.Api.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class UserTableTimestamp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedOn",
+                table: "Users",
+                type: "datetime(6)",
+                rowVersion: true,
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)")
+                .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.ComputedColumn);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedOn",
+                table: "Users",
+                type: "datetime(6)",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldRowVersion: true)
+                .OldAnnotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.ComputedColumn);
+        }
+    }
+}

--- a/src/Nullinside.Api.Model/Shared/DatabaseLock.cs
+++ b/src/Nullinside.Api.Model/Shared/DatabaseLock.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore;
+
+using Nullinside.Api.Model;
+
+namespace Nullinside.Api.Common;
+
+/// <summary>
+/// Handles acquiring a lock at the database level.
+/// </summary>
+/// <remarks>Requires a transaction wrapping its functionality.</remarks>
+public class DatabaseLock : IDisposable {
+  /// <summary>
+  /// The database context.
+  /// </summary>
+  private INullinsideContext _mysqlDbContext;
+  /// <summary>
+  /// The lock name used on the previous lock.
+  /// </summary>
+  private string? _name;
+  
+  /// <summary>
+  /// Initializes a new instance of the <see cref="DatabaseLock"/> class.
+  /// </summary>
+  /// <param name="mysqlDbContext">The database context.</param>
+  /// <exception cref="ArgumentNullException">Must provide parameter.</exception>
+  public DatabaseLock(INullinsideContext mysqlDbContext) {
+    _mysqlDbContext = mysqlDbContext ?? throw new ArgumentNullException(nameof(mysqlDbContext));
+  }
+
+  /// <summary>
+  /// Acquires the lock.
+  /// </summary>
+  /// <remarks>Waits indefinitely.</remarks>
+  /// <param name="name">The name of the lock. MUST BE A HARD CODED VALUE</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  /// <returns>True if successful, false otherwise.</returns>
+  public async Task<bool> GetLock(string name, CancellationToken cancellationToken = new()) {
+    if (string.IsNullOrWhiteSpace(name)) {
+      return false;
+    }
+    
+    // This is only used with hard coded names.
+#pragma warning disable EF1002
+    await _mysqlDbContext.Database.ExecuteSqlRawAsync($"SELECT GET_LOCK('{name}', -1)", cancellationToken: cancellationToken);
+#pragma warning restore EF1002
+    _name = name;
+    return true;
+  }
+  
+  /// <summary>
+  /// Releases the lock.
+  /// </summary>
+  /// <param name="name">The name of the lock. MUST BE A HARD CODED VALUE</param>
+  /// <param name="cancellationToken">The cancellation token.</param>
+  public async Task ReleaseLock(string name, CancellationToken cancellationToken = new()) {
+    if (!string.IsNullOrWhiteSpace(name) && !name.Equals(_name, StringComparison.InvariantCultureIgnoreCase)) {
+      // This is only used with hard coded names.
+#pragma warning disable EF1002
+      await _mysqlDbContext.Database.ExecuteSqlRawAsync($"SELECT RELEASE_LOCK('{_name}')", cancellationToken: cancellationToken);
+#pragma warning restore EF1002
+    }
+    
+    // This is only used with hard coded names.
+#pragma warning disable EF1002
+    await _mysqlDbContext.Database.ExecuteSqlRawAsync($"SELECT RELEASE_LOCK('{name}')", cancellationToken: cancellationToken);
+#pragma warning restore EF1002
+    _name = null;
+  }
+
+  /// <summary>
+  /// Disposes of resources.
+  /// </summary>
+  /// <param name="disposing">True if dispose called, false if finalizer.</param>
+  protected virtual void Dispose(bool disposing) {
+    if (disposing) {
+      if (!string.IsNullOrWhiteSpace(_name)) {
+        Task.WaitAll(this.ReleaseLock(_name));
+      }
+    }
+  }
+
+  /// <inheritdoc />
+  public void Dispose() {
+    Dispose(true);
+    GC.SuppressFinalize(this);
+  }
+
+  /// <summary>
+  /// Finalizes instance of the <see cref="DatabaseLock"/> class.
+  /// </summary>
+  ~DatabaseLock() {
+    Dispose(false);
+  }
+}


### PR DESCRIPTION
Preventing multiple threads from updating the bot's oauth token using a
database level lock. It's a bit of a hack since ef core doesn't support
pessmistic locking out-of-the-box. This work around works between the
running application and dbeaver.