### PR TITLE
fix: duplicate insertion issue

### DIFF
--- a/src/Nullinside.Api.Model/Ddl/TwitchBan.cs
+++ b/src/Nullinside.Api.Model/Ddl/TwitchBan.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 
+using MySql.EntityFrameworkCore.Extensions;
+
 namespace Nullinside.Api.Model.Ddl;
 
 /// <summary>
@@ -39,6 +41,8 @@ public class TwitchBan : ITableModel {
   public void OnModelCreating(ModelBuilder modelBuilder) {
     modelBuilder.Entity<TwitchBan>(entity => {
       entity.HasKey(e => e.Id);
+      entity.Property(e => e.Id)
+        .UseMySQLAutoIncrementColumn("int");
       entity.Property(e => e.ChannelId)
         .HasMaxLength(255);
       entity.Property(e => e.BannedUserTwitchId)

--- a/src/Nullinside.Api.Model/Migrations/NullinsideContextModelSnapshot.cs
+++ b/src/Nullinside.Api.Model/Migrations/NullinsideContextModelSnapshot.cs
@@ -16,7 +16,7 @@ namespace Nullinside.Api.Model.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "8.0.11")
+                .HasAnnotation("ProductVersion", "8.0.13")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
             modelBuilder.Entity("Nullinside.Api.Model.Ddl.DockerDeployments", b =>


### PR DESCRIPTION
Trying to fix the duplicate insertion issue. I'm guessing that EF Core is trying to determine the value before insertion rather than letting the database do it at insertion time. Trying this method to see if it fixes the issue

nullinside-development-group/nullinside-api#70