### PR TITLE
fix: twitch client not receiving updated credentials

### DIFF
--- a/src/Nullinside.Api.Common/Twitch/TwitchClientProxy.cs
+++ b/src/Nullinside.Api.Common/Twitch/TwitchClientProxy.cs
@@ -73,6 +73,8 @@ public class TwitchClientProxy : ITwitchClientProxy {
   /// </summary>
   private WebSocketClient? socket;
 
+  private string? _twitchOAuthToken;
+
   /// <summary>
   ///   Initializes a new instance of the <see cref="TwitchClientProxy" /> class.
   /// </summary>
@@ -103,7 +105,18 @@ public class TwitchClientProxy : ITwitchClientProxy {
   public string? TwitchUsername { get; set; }
 
   /// <inheritdoc />
-  public string? TwitchOAuthToken { get; set; }
+  public string? TwitchOAuthToken {
+    get => _twitchOAuthToken;
+    set {
+      _twitchOAuthToken = value;
+      
+      // If we have a client, try to connect.
+      if (null != client) {
+        client.SetConnectionCredentials(new ConnectionCredentials(TwitchUsername, value));
+        Connect();
+      }
+    }
+  }
 
   /// <inheritdoc />
   public void Dispose() {


### PR DESCRIPTION
If the credentials needed to change (not be set for the first time but actually change from one value to another), their value wasn't being pushed to the underlying client. We now pass the credentials to the same place as the initialization.

closes nullinside-development-group/twitch-streaming-tools#20