### PR TITLE
fix: error message when changing credentials

### DIFF
--- a/src/Nullinside.Api.Common/Twitch/TwitchClientProxy.cs
+++ b/src/Nullinside.Api.Common/Twitch/TwitchClientProxy.cs
@@ -108,10 +108,15 @@ public class TwitchClientProxy : ITwitchClientProxy {
   public string? TwitchOAuthToken {
     get => _twitchOAuthToken;
     set {
+      if (value == _twitchOAuthToken) {
+        return;
+      }
+      
       _twitchOAuthToken = value;
 
       // If we have a client, try to connect.
       if (null != _client) {
+        _client.Disconnect();
         _client.SetConnectionCredentials(new ConnectionCredentials(TwitchUsername, value));
         Connect();
       }


### PR DESCRIPTION
Received error message: TwitchLib.Client.Exceptions.IllegalAssignmentException: While the client is connected, you are unable to change the connection credentials. Please disconnect first and then change them.

Updating the code to only run the credential changes when there is an actual change. Disconnecting before we change the credentials.