### PR TITLE
fix: failure to update with inner folders

### DIFF
--- a/src/Nullinside.Api.Common/Desktop/GitHubUpdateManager.cs
+++ b/src/Nullinside.Api.Common/Desktop/GitHubUpdateManager.cs
@@ -167,6 +167,10 @@ public static class GitHubUpdateManager {
           File.Delete(file);
         }
 
+        foreach (var directory in Directory.GetDirectories(folder)) {
+          Directory.Delete(directory, true);
+        }
+
         return Task.FromResult(true);
       }, 30, waitTime: TimeSpan.FromSeconds(1));
     }


### PR DESCRIPTION
We still have the issue where the previous install folder is locked while the updating application in a different folder is running. (don't ask I haven't figured out why yet)

So we can recursively delete the inner folders just not the outermost one.