### PR TITLE
bug: fixing subscription issue with twitch client chat messages

### DIFF
--- a/src/Nullinside.Api.Common/Twitch/TwitchClientProxy.cs
+++ b/src/Nullinside.Api.Common/Twitch/TwitchClientProxy.cs
@@ -188,6 +188,7 @@ public class TwitchClientProxy : ITwitchClientProxy {
     string channelSan = channel.ToLowerInvariant();
     lock (_onMessageReceived) {
       if (!_onMessageReceived.TryAdd(channelSan, callback)) {
+        _onMessageReceived[channelSan] -= callback;
         _onMessageReceived[channelSan] += callback;
       }
     }


### PR DESCRIPTION
When I modified the code to be channel specific I completely forgot that +=ing a delegate will append copies if you don't -= the item first. Fixed it now. The -= will ensure that only a single copy of the subscription is added to the chain.