### PR TITLE
chore: removing pdb from publish

### DIFF
--- a/src/Nullinside.Api.Common/Nullinside.Api.Common.csproj
+++ b/src/Nullinside.Api.Common/Nullinside.Api.Common.csproj
@@ -14,6 +14,7 @@
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <DocumentationFile>bin\Release\Nullinside.Api.Common.xml</DocumentationFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <DebugType>none</DebugType>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The interface for turning off the pdbs in release is very weird. Its unchecked but it was still generating them because the drop down beneath it wasn't set to none. This should fix the drop down.