### PR TITLE
feat: making validate token return state instead of using http status

### DIFF
--- a/src/Nullinside.Api.Tests/Nullinside.Api/Controllers/UserControllerTests.cs
+++ b/src/Nullinside.Api.Tests/Nullinside.Api/Controllers/UserControllerTests.cs
@@ -318,7 +318,8 @@ public class UserControllerTests : UnitTestBase {
     // Make the call and ensure it fails.
     var controller = new TestableUserController(_configuration, _db, _webSocketPersister.Object);
     IActionResult obj = await controller.Validate(new AuthToken("123")).ConfigureAwait(false);
-    Assert.That((obj as IStatusCodeActionResult)?.StatusCode, Is.EqualTo(401));
+    Assert.That((obj as IStatusCodeActionResult)?.StatusCode, Is.EqualTo(200));
+    Assert.That((obj as ObjectResult)?.Value, Is.False);
   }
 
   /// <summary>

--- a/src/Nullinside.Api/Controllers/UserController.cs
+++ b/src/Nullinside.Api/Controllers/UserController.cs
@@ -309,7 +309,7 @@ public class UserController : ControllerBase {
     try {
       User? existing = await _dbContext.Users.FirstOrDefaultAsync(u => u.Token == token.Token && !u.IsBanned, cancellationToken).ConfigureAwait(false);
       if (null == existing) {
-        return Unauthorized();
+        return Ok(false);
       }
 
       return Ok(true);


### PR DESCRIPTION
It's less confusing and more in-line with rest api standards I've seen out in the world to return the result as a boolean rather than relying on the 401 http status. Makes the logs cleaner too.

nullinside-development-group/nullinside-ui#175