### PR TITLE
feat: adding twitch username/id to user table from login

### DIFF
--- a/src/Nullinside.Api/Controllers/UserController.cs
+++ b/src/Nullinside.Api/Controllers/UserController.cs
@@ -153,7 +153,8 @@ public class UserController : ControllerBase {
       return Redirect($"{siteUrl}/user/login?error=4");
     }
 
-    OAuthToken? bearerToken = await UserHelpers.GenerateTokenAndSaveToDatabase(_dbContext, email, Constants.OAUTH_TOKEN_TIME_LIMIT, cancellationToken: token).ConfigureAwait(false);
+    TwitchLib.Api.Helix.Models.Users.GetUsers.User? twitchInfo = await api.GetUser(token).ConfigureAwait(false);
+    OAuthToken? bearerToken = await UserHelpers.GenerateTokenAndSaveToDatabase(_dbContext, email, Constants.OAUTH_TOKEN_TIME_LIMIT, twitchUsername: twitchInfo?.Login, twitchId: twitchInfo?.Id, cancellationToken: token).ConfigureAwait(false);
     if (null == bearerToken) {
       return Redirect($"{siteUrl}/user/login?error=2");
     }


### PR DESCRIPTION
We didn't previously record the twitch username or user id when you did a normal login to the site, outside of the twitch bot. There is no harm to grabbing that information, in fact it will help us link the accounts later.

We were very careful not to overwrite the oauth token from twitch as the regular login has severly less permissions than the twitch bot login.