### PR TITLE
feat: extending time for oauth tokens

### DIFF
--- a/src/Nullinside.Api/Constants.cs
+++ b/src/Nullinside.Api/Constants.cs
@@ -7,5 +7,5 @@ public static class Constants {
   /// <summary>
   ///   The amount of time a token is valid for.
   /// </summary>
-  public static readonly TimeSpan OAUTH_TOKEN_TIME_LIMIT = TimeSpan.FromHours(1);
+  public static readonly TimeSpan OAUTH_TOKEN_TIME_LIMIT = TimeSpan.FromDays(7);
 }


### PR DESCRIPTION
I believe the 1hr limit was for testing and I forgot to change it.