### PR TITLE
feat: excluding banned users and users not enabled

### DIFF
--- a/src/Nullinside.Api/Controllers/TwitchController.cs
+++ b/src/Nullinside.Api/Controllers/TwitchController.cs
@@ -66,8 +66,19 @@ public class TwitchController : ControllerBase {
       ExpiresUtc = botUser.TwitchTokenExpiration
     };
 
+    DateTime earliestScan = DateTime.UtcNow.AddHours(-1);
+#if DEBUG
+    earliestScan = DateTime.UtcNow.AddDays(-365);
+#endif
+
     List<User> users = await _dbContext.Users
-      .Where(u => !string.IsNullOrWhiteSpace(u.TwitchId) && u.TwitchLastScanned > DateTime.UtcNow.AddHours(-1))
+      .Include(u => u.TwitchConfig)
+      .Where(u =>
+        !u.IsBanned &&
+        null != u.TwitchConfig &&
+        u.TwitchConfig.Enabled &&
+        !string.IsNullOrWhiteSpace(u.TwitchId) &&
+        u.TwitchLastScanned > earliestScan)
       .ToListAsync(token)
       .ConfigureAwait(false);
     if (users.Count == 0) {


### PR DESCRIPTION
The carousel was picking up a user that logged into the nullinside bot but turned it off.